### PR TITLE
Fix/fixes issue 128

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -200,8 +200,11 @@
 
   gulp.task("test:unit:widget", factory.testUnitAngular(
     {testFiles: [
+      "src/components/underscore/underscore.js",
+      "src/widget/content.js",
       "src/widget/utils.js",
       "src/widget/images.js",
+      "test/unit/widget/content-spec.js",
       "test/unit/widget/utils-spec.js",
       "test/unit/widget/images-spec.js"
     ]}

--- a/src/widget/content.js
+++ b/src/widget/content.js
@@ -12,7 +12,8 @@ RiseVision.RSS.Content = function( prefs, params ) {
     _utils = RiseVision.RSS.Utils,
     _images = RiseVision.RSS.Images,
     _transition = null,
-    _imageTypes = [ "image/bmp", "image/gif", "image/jpeg", "image/jpg", "image/png", "image/tiff" ];
+    _imageTypes = [ "image/bmp", "image/gif", "image/jpeg", "image/jpg", "image/png", "image/tiff" ],
+    _imageExtensions = [ "bmp", "gif", "jpeg", "jpg", "png", "tiff" ];
 
   /*
    *  Private Methods
@@ -28,10 +29,25 @@ RiseVision.RSS.Content = function( prefs, params ) {
     }
   }
 
-  function _getImageUrl( item ) {
+  function isValidImageInEnclosure( enclosure ) {
+    var contentType = enclosure.type,
+      start,
+      extension;
+
+    if ( contentType === "image" && enclosure.url ) {
+      start = enclosure.url.lastIndexOf( "." ) + 1,
+      extension = enclosure.url.substr( start );
+
+      return _.contains( _imageExtensions, extension );
+    }
+
+    return _.contains( _imageTypes, contentType );
+  }
+
+  function getImageUrl( item ) {
     var imageUrl = null;
 
-    if ( _.has( item, "enclosures" ) && item.enclosures[ 0 ] && ( _.contains( _imageTypes, item.enclosures[ 0 ].type ) ) ) {
+    if ( _.has( item, "enclosures" ) && item.enclosures[ 0 ] && isValidImageInEnclosure( item.enclosures[ 0 ] ) ) {
       imageUrl = item.enclosures[ 0 ].url;
     } else if ( item.image && item.image.url ) {
       imageUrl = item.image.url;
@@ -45,7 +61,7 @@ RiseVision.RSS.Content = function( prefs, params ) {
       i;
 
     for ( i = 0; i < _items.length; i += 1 ) {
-      urls.push( _getImageUrl( _items[ i ] ) );
+      urls.push( getImageUrl( _items[ i ] ) );
     }
 
     return urls;
@@ -109,7 +125,7 @@ RiseVision.RSS.Content = function( prefs, params ) {
     var title = getTitle( item ),
       story = getStory( item ),
       author = getAuthor( item ),
-      imageUrl = _getImageUrl( item ),
+      imageUrl = getImageUrl( item ),
       date = getDate( item ),
       template = document.querySelector( "#layout" ).content,
       $content = $( template.cloneNode( true ) ),
@@ -365,6 +381,7 @@ RiseVision.RSS.Content = function( prefs, params ) {
     init: init,
     getAuthor: getAuthor,
     getDate: getDate,
+    getImageUrl: getImageUrl,
     getStory: getStory,
     getTitle: getTitle,
     loadImages: loadImages,

--- a/src/widget/content.js
+++ b/src/widget/content.js
@@ -29,7 +29,7 @@ RiseVision.RSS.Content = function( prefs, params ) {
     }
   }
 
-  function isValidImageInEnclosure( enclosure ) {
+  function _isValidImageInEnclosure( enclosure ) {
     var contentType = enclosure.type,
       start,
       extension;
@@ -47,7 +47,7 @@ RiseVision.RSS.Content = function( prefs, params ) {
   function getImageUrl( item ) {
     var imageUrl = null;
 
-    if ( _.has( item, "enclosures" ) && item.enclosures[ 0 ] && isValidImageInEnclosure( item.enclosures[ 0 ] ) ) {
+    if ( _.has( item, "enclosures" ) && item.enclosures[ 0 ] && _isValidImageInEnclosure( item.enclosures[ 0 ] ) ) {
       imageUrl = item.enclosures[ 0 ].url;
     } else if ( item.image && item.image.url ) {
       imageUrl = item.image.url;

--- a/test/unit/widget/content-spec.js
+++ b/test/unit/widget/content-spec.js
@@ -1,0 +1,98 @@
+/* global describe, it, assert, RiseVision */
+
+/* eslint-disable func-names */
+
+"use strict";
+
+describe( "getImageUrl", function() {
+
+  it( "should extract an image URL", function() {
+    var item = {
+        "enclosures": [ {
+          "url": "https://static01.nyt.com/images/2018/11/02/business/02apple/02apple-moth.jpg",
+          "type": "image/jpg",
+          "length": null,
+          "height": "151",
+          "width": "151"
+        } ]
+      },
+      url = RiseVision.RSS.Content( null, {} ).getImageUrl( item );
+
+    assert.equal( url, "https://static01.nyt.com/images/2018/11/02/business/02apple/02apple-moth.jpg" );
+  } );
+
+  it( "should not extract an image URL when the content type is invalid", function() {
+    var item = {
+        "enclosures": [ {
+          "url": "https://static01.nyt.com/images/2018/11/02/business/02apple/02apple-moth.jpg",
+          "type": "image/invalid",
+          "length": null,
+          "height": "151",
+          "width": "151"
+        } ]
+      },
+      url = RiseVision.RSS.Content( null, {} ).getImageUrl( item );
+
+    assert.isNull( url );
+  } );
+
+  it( "should extract an image URL when content type is generic image and extension is valid", function() {
+    var item = {
+        "enclosures": [ {
+          "url": "https://static01.nyt.com/images/2018/11/02/business/02apple/02apple-moth.jpg",
+          "type": "image",
+          "length": null,
+          "height": "151",
+          "width": "151"
+        } ]
+      },
+      url = RiseVision.RSS.Content( null, {} ).getImageUrl( item );
+
+    assert.equal( url, "https://static01.nyt.com/images/2018/11/02/business/02apple/02apple-moth.jpg" );
+  } );
+
+  it( "should not extract an image URL when content type is generic image and extension is not valid", function() {
+    var item = {
+        "enclosures": [ {
+          "url": "https://static01.nyt.com/images/2018/11/02/business/02apple/02apple-moth.invalid",
+          "type": "image",
+          "length": null,
+          "height": "151",
+          "width": "151"
+        } ]
+      },
+      url = RiseVision.RSS.Content( null, {} ).getImageUrl( item );
+
+    assert.isNull( url );
+  } );
+
+  it( "should not extract an image URL when content type is generic image and URL is not valid", function() {
+    var item = {
+        "enclosures": [ {
+          "url": "invalid",
+          "type": "image",
+          "length": null,
+          "height": "151",
+          "width": "151"
+        } ]
+      },
+      url = RiseVision.RSS.Content( null, {} ).getImageUrl( item );
+
+    assert.isNull( url );
+  } );
+
+  it( "should not extract an image URL when content type is generic image and there is no URL", function() {
+    var item = {
+        "enclosures": [ {
+          "type": "image",
+          "length": null,
+          "height": "151",
+          "width": "151"
+        } ]
+      },
+      url = RiseVision.RSS.Content( null, {} ).getImageUrl( item );
+
+    assert.isNull( url );
+  } );
+
+} );


### PR DESCRIPTION
The feed is reporting a content type of just "image" instead of something "image/png" or "image/jpg", so our current implementation is not recognizing a valid image.

To fix that I check for the file extension in the URL if the content type is just "image". This now works here:

https://apps.risevision.com/editor/workspace/9550cc2d-9bb4-418c-a219-d7387aab7d70/?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

I added unit tests for the current extraction logic, and also for these new scenarios.
