### PR TITLE
Only log ETIMEDOUT error upon receiving at least 3 consecutive times

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Description
+Include a summary of the change. If this is fixing a defect, ensure to link to the issue this is fixing.
+
+## Motivation and Context
+Why is this change required? What problem does it solve?
+
+## How Has This Been Tested?
+Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.
+
+## Release Plan:
+- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
+- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
+
+#### Release Checklist Items Skipped?
+If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

--- a/src/widget/rise-rss.js
+++ b/src/widget/rise-rss.js
@@ -5,7 +5,8 @@ RiseVision.RSS = RiseVision.RSS || {};
 RiseVision.RSS.RiseRSS = function( data ) {
   "use strict";
 
-  var _initialLoad = true;
+  var _initialLoad = true,
+    _timedOutCount = 0;
 
   /*
    *  Public Methods
@@ -14,6 +15,8 @@ RiseVision.RSS.RiseRSS = function( data ) {
     var rss = document.querySelector( "rise-rss" );
 
     rss.addEventListener( "rise-rss-response", function( e ) {
+      _timedOutCount = 0;
+
       if ( e.detail && e.detail.feed ) {
         if ( _initialLoad ) {
           _initialLoad = false;
@@ -57,6 +60,13 @@ RiseVision.RSS.RiseRSS = function( data ) {
         RiseVision.RSS.showError( "Sorry, there was a problem requesting the RSS feed, please contact the owner of the RSS feed to resolve." );
       } else {
         RiseVision.RSS.showError( "Sorry, there was a problem with the RSS feed." );
+      }
+
+      _timedOutCount = errorDetails.toUpperCase().indexOf( "ETIMEDOUT" ) !== -1 ? _timedOutCount + 1 : 0;
+
+      if ( _timedOutCount > 0 && _timedOutCount < 3 ) {
+        // prevent logging an ETIMEDOUT error until it occurs at least 3 consecutive times
+        return;
       }
 
       RiseVision.RSS.logEvent( params );

--- a/test/integration/logging-rise-rss.html
+++ b/test/integration/logging-rise-rss.html
@@ -181,6 +181,66 @@
           assert(spy.calledWith(table, params));
           done();
         });
+
+        test("should log a ETIMEDOUT error only after receiving 3 consecutive times", function(done) {
+          spy = sinon.spy(RiseVision.Common.LoggerUtils, "logEvent");
+
+          rss.dispatchEvent(new CustomEvent("rise-rss-error", {
+            "detail": "ETIMEDOUT",
+            "bubbles": true
+          }));
+
+          params.event = "error";
+          params.event_details = "rise rss error";
+          params.error_details = "ETIMEDOUT";
+
+          assert.isFalse(spy.calledOnce);
+
+          rss.dispatchEvent(new CustomEvent("rise-rss-error", {
+            "detail": "ETIMEDOUT",
+            "bubbles": true
+          }));
+
+          assert.isFalse(spy.calledOnce);
+
+          rss.dispatchEvent(new CustomEvent("rise-rss-error", {
+            "detail": "ETIMEDOUT",
+            "bubbles": true
+          }));
+
+          assert(spy.calledOnce);
+          assert(spy.calledWith(table, params));
+          done();
+        });
+
+        test("should reset ETIMEDOUT error count when different error is received", function(done) {
+          spy = sinon.spy(RiseVision.Common.LoggerUtils, "logEvent");
+
+          rss.dispatchEvent(new CustomEvent("rise-rss-error", {
+            "detail": "ETIMEDOUT",
+            "bubbles": true
+          }));
+
+          // count is already over 3 from previous test case
+          assert(spy.calledOnce);
+
+          rss.dispatchEvent(new CustomEvent("rise-rss-error", {
+            "detail": "Bad status code: 403 message: Forbidden",
+            "bubbles": true
+          }));
+
+          assert(spy.calledTwice);
+
+          rss.dispatchEvent(new CustomEvent("rise-rss-error", {
+            "detail": "ETIMEDOUT",
+            "bubbles": true
+          }));
+
+          // ETIMEDOUT count was reset from previous error
+          assert.isFalse(spy.calledThrice);
+
+          done();
+        });
       });
 
     });


### PR DESCRIPTION
## Description
Prevent ETIMEDOUT errors from being reported to BQ unless they have been received at least 3 consecutive times

## Motivation and Context
ETIMEDOUT error are typically due to the server the feed is on responding slowly when feed-parser requests it, hence its not a direct issue with the widget, component, or feed parser. Logs indicate that the Widget sometimes successfully receives rss data on further refresh requests after a previous ETIMEDOUT error, so given this, we should not allow reliability to be negatively impacted if the Widget does get data after a couple _retries_. 

## How Has This Been Tested?
Tested widget works as expected locally and with staged version of Widget in Preview and ChrOS player. There isn't a specific way I can manually force an ETIMEDOUT situation, but automated integration tests have been added. 

https://apps.risevision.com/editor/workspace/3c20ec0c-b810-4fbb-838e-f32d7af20da5?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manually tested widget works as expected
  - Automated integration tests added
  - Deployment will happen Monday (no deployments on Fridays)
  - Monitoring plan will consist of validating on production no issues, taking 3 random displays running RSS and rebooting them, and periodically checking logs throughout day and next day
  - Rollback consists of re-running previous master build on CCI followed by reverting code changes in repo
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- No documentation required
- Support not required to be notified as there is no user blocked