### PR TITLE
Fix/chrome 80

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,7 @@
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.5.0",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
     "xmlToJSON.js": "^1.3.2",
-    "webcomponentsjs": "v1.1.0"
+    "webcomponentsjs": "v0.7.24"
   },
   "resolutions": {
     "angular": "~1.7.0",
@@ -51,6 +51,6 @@
     "gsap": "~1.13.2",
     "jquery": "~3.3.1",
     "lodash": "~4.17.15",
-    "webcomponentsjs": "v1.1.0"
+    "webcomponentsjs": "v0.7.24"
   }
 }

--- a/src/widget.html
+++ b/src/widget.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>RSS Widget</title>
 
-  <script src="components/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="components/webcomponentsjs/webcomponents.js"></script>
   <script src="components/underscore/underscore.js"></script>
 
   <link rel="import" href="components/rise-rss/rise-rss.html">

--- a/src/widget.html
+++ b/src/widget.html
@@ -6,6 +6,7 @@
   <title>RSS Widget</title>
 
   <script src="components/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="components/underscore/underscore.js"></script>
 
   <link rel="import" href="components/rise-rss/rise-rss.html">
 

--- a/src/widget/rise-rss.js
+++ b/src/widget/rise-rss.js
@@ -14,6 +14,18 @@ RiseVision.RSS.RiseRSS = function( data ) {
   function init() {
     var rss = document.querySelector( "rise-rss" );
 
+    if ( !rss.go ) {
+      setTimeout( function() {
+        init();
+      }, 100 );
+
+      return;
+    }
+
+    _initRss( rss );
+  }
+
+  function _initRss( rss ) {
     rss.addEventListener( "rise-rss-response", function( e ) {
       _timedOutCount = 0;
 

--- a/src/widget/rise-rss.js
+++ b/src/widget/rise-rss.js
@@ -15,9 +15,7 @@ RiseVision.RSS.RiseRSS = function( data ) {
     var rss = document.querySelector( "rise-rss" );
 
     if ( !rss.go ) {
-      setTimeout( function() {
-        init();
-      }, 100 );
+      setTimeout( init, 100 );
 
       console.log( "rise-rss component still not initialized; retrying" ); // eslint-disable-line no-console
       return;

--- a/src/widget/rise-rss.js
+++ b/src/widget/rise-rss.js
@@ -19,6 +19,7 @@ RiseVision.RSS.RiseRSS = function( data ) {
         init();
       }, 100 );
 
+      console.log( "rise-rss component still not initialized; retrying" ); // eslint-disable-line no-console
       return;
     }
 


### PR DESCRIPTION
## Description
Fixes Chrome 80 incompatibilities

## Motivation and Context
Implements webcomponents polyfills v0. Because those polyfills result in webcomponents features to be loaded asynchronously, two additional changes were implemented to ensure RSS widget works properly on Chrome 80:

- Load underscore library synchronously
- Wait until the RSS component is available before interacting with it using a timeout. Trying to rely on *WebComponentsReady* event never worked.

## How Has This Been Tested?
Manually tested in this presentation on both chrome <80 and beta ( 80 ) -
https://apps.risevision.com/editor/workspace/87dadfa4-488c-4267-b080-bd61e4cb5ed4?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

And tested in Rise Player using this presentation:
https://apps.risevision.com/schedules/details/672c4c6c-1130-473e-ae4d-121650aa945f?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - To be released before Friday
     - Widget will immediately be tested after production deployment.
     - Simple rollback is needed in case of problems.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support, no need to update documentation, no need for additional tests.
